### PR TITLE
Archiving big files causes huge memory usage

### DIFF
--- a/src/Pim/Component/Connector/Archiver/ArchivableFileWriterArchiver.php
+++ b/src/Pim/Component/Connector/Archiver/ArchivableFileWriterArchiver.php
@@ -57,7 +57,9 @@ class ArchivableFileWriterArchiver extends AbstractFilesystemArchiver
                 );
 
                 foreach ($writer->getWrittenFiles() as $fullPath => $localPath) {
-                    $filesystem->put($localPath, file_get_contents($fullPath));
+                    $stream = fopen($fullPath, 'r');
+                    $filesystem->putStream($localPath, $stream);
+                    fclose($stream);
                 }
             }
         }


### PR DESCRIPTION
The ArchivableFileWriterArchiver is using streams to write to the zip
archive, but it reads the content of the source file using
file_get_contents.

This behaviour is changed to also use a stream to read the source file
and use putStream of flysystem to add content to the target archive.