### PR TITLE
Detach read items on export job

### DIFF
--- a/src/Pim/Bundle/ConnectorBundle/Resources/config/steps.yml
+++ b/src/Pim/Bundle/ConnectorBundle/Resources/config/steps.yml
@@ -217,6 +217,7 @@ services:
             - '@pim_connector.processor.normalization.product'
             - '@pim_connector.writer.file.csv_product'
             - 10
+            - '@akeneo_storage_utils.doctrine.object_detacher'
 
     pim_connector.step.csv_category.export:
         class: '%pim_connector.step.item_step.class%'


### PR DESCRIPTION
The memory consumption of export jobs constantly increases if products
with associations are exported.

The fix detaches the read items together with their associations and
products collected in the associations.
